### PR TITLE
New refundCreate API method for GraphQL mutation of the same name

### DIFF
--- a/.docker/Dockerfile.example
+++ b/.docker/Dockerfile.example
@@ -1,0 +1,27 @@
+# Uncomment the php version that you want to test.
+# FROM php:7.3-cli
+# FROM php:7.4-cli
+# FROM php:8.0-cli
+# FROM php:8.1-cli
+# FROM php:8.2-cli
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    git \
+    curl \
+    zip \
+    unzip
+
+# Clear cache
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install composer (get latest v2)
+RUN curl -sS https://getcomposer.org/installer | php -- --2 --install-dir=/usr/local/bin --filename=composer
+
+COPY . /usr/src/sdk
+WORKDIR /usr/src/sdk
+
+CMD [ "php"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,25 @@
+# Composer files
+/vendor/
 composer.lock
+composer.phar
+
+# PHPUnit report
+/tests/report/
+/clover.xml
+/phpunit.xml
+.phpunit.result.cache
+
+# Environment files
+.env
 
 # IDE
 .idea/
+
+# Docker files used for local testing of different PHP versions.
+docker-compose.yml
+/.docker/**/*
+/Dockerfile
+
+# Exclude Dockerfile example to be used with docker compose example
+# Allows to setup different PHP versions for local test of library in different php versions.
+!/.docker/Dockerfile.example

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,15 @@
         "psr-4": {
             "Rvvup\\Sdk\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Rvvup\\Sdk\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
-        "phpstan/phpstan": "1.7.x",
+        "phpstan/phpstan": "^1.7",
         "phpunit/phpunit": "^9",
-        "squizlabs/php_codesniffer": ">=3.7"
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "ext-curl": "*",
         "ext-json": "*",
-        "php": "^7.1 || ^8.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         "php": "^7.3 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
         "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
         "phpstan/phpstan": "1.7.x",
+        "phpunit/phpunit": "^9",
         "squizlabs/php_codesniffer": ">=3.7"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,9 @@
         "guzzlehttp/guzzle": ">=6"
     },
     "require": {
-        "psr/http-client": "^1",
+        "php": "^7.3 || ^8.0",
         "ext-curl": "*",
-        "ext-json": "*",
-        "php": "^7.3 || ^8.0"
+        "ext-json": "*"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
@@ -30,6 +29,7 @@
         }
     },
     "config": {
+        "sort-packages": true,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "guzzlehttp/guzzle": ">=6"
     },
     "require": {
+        "psr/http-client": "^1",
         "ext-curl": "*",
         "ext-json": "*",
         "php": "^7.3 || ^8.0"

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,24 @@
+version: '3.3'
+services:
+
+  #PHP Service
+  app:
+    build:
+      context: .
+      dockerfile: ./.docker/Dockerfile
+    container_name: app
+    restart: unless-stopped
+    tty: true
+    environment:
+      SERVICE_NAME: app
+      SERVICE_TAGS: dev
+    working_dir: /usr/src/sdk
+    volumes:
+      - ./:/usr/src/sdk
+    networks:
+      - app-network
+
+#Docker Networks
+networks:
+  app-network:
+    driver: bridge

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <clover outputFile="clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+</phpunit>

--- a/src/Exceptions/NetworkException.php
+++ b/src/Exceptions/NetworkException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Sdk\Exceptions;
+
+use Exception;
+
+class NetworkException extends Exception
+{
+    // Custom exception for network errors where we assume the request is picked up by Rvvup..
+}

--- a/src/Factories/Inputs/RefundCreateInputFactory.php
+++ b/src/Factories/Inputs/RefundCreateInputFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Sdk\Factories\Inputs;
+
+use Rvvup\Sdk\Inputs\InputInterface;
+use Rvvup\Sdk\Inputs\RefundCreateInput;
+
+/**
+ * Factory to generate a RefundCreateInput class. It should be used instead of the class itself.
+ */
+class RefundCreateInputFactory
+{
+    /**
+     * Get a new RefundCreateInput model.
+     *
+     * @param string $orderId
+     * @param string $amount
+     * @param string $currency
+     * @param string $idempotencyKey
+     * @param string|null $reason
+     * @return \Rvvup\Sdk\Inputs\InputInterface|\Rvvup\Sdk\Inputs\RefundCreateInput
+     */
+    public function create(
+        string $orderId,
+        string $amount,
+        string $currency,
+        string $idempotencyKey,
+        ?string $reason = null
+    ): InputInterface {
+        return new RefundCreateInput($orderId, $amount, $currency, $idempotencyKey, $reason ?? '');
+    }
+}

--- a/src/GraphQlSdk.php
+++ b/src/GraphQlSdk.php
@@ -11,14 +11,30 @@ class GraphQlSdk
     private $merchantId;
     /** @var string */
     private $authToken;
-    /** @var \Psr\Log\LoggerInterface */
-    private $logger;
-    /** @var bool */
-    private $debug;
     /** @var string */
     private $userAgent;
-    /** @var Curl */
+
+    /**
+     * An HTTP Client similar to Guzzle's HTTP Client.
+     * ToDo: Refactor to use PSR-18 Interface
+     *
+     * @var Curl
+     */
     private $adapter;
+
+    /**
+     * A Logger implementation (eg PSR Logger).
+     *
+     * @var null
+     */
+    private $logger;
+
+    /**
+     * Enable debug logging.
+     *
+     * @var bool
+     */
+    private $debug;
 
     /**
      * @param string $endpoint

--- a/src/GraphQlSdk.php
+++ b/src/GraphQlSdk.php
@@ -2,6 +2,7 @@
 
 namespace Rvvup\Sdk;
 
+use Rvvup\Sdk\Exceptions\NetworkException;
 use Rvvup\Sdk\Inputs\RefundCreateInput;
 
 class GraphQlSdk
@@ -543,6 +544,7 @@ QUERY;
      * @param null $variables
      * @param array|null $inputOptions
      * @return mixed
+     * @throws \Rvvup\Sdk\Exceptions\NetworkException
      * @throws \JsonException
      * @throws \Exception
      */
@@ -596,6 +598,13 @@ QUERY;
                 $this->log("Successful GraphQL request", $debugData);
             }
             return $processed;
+        }
+
+        if ($responseCode >= 500 && $responseCode < 600) {
+            throw new NetworkException(
+                'There was a network error returned via the API. Please use the same idempotency if you retry',
+                500
+            );
         }
 
         //Unexpected HTTP response code

--- a/src/Inputs/InputInterface.php
+++ b/src/Inputs/InputInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Sdk\Inputs;
+
+interface InputInterface
+{
+    // Placeholder Interface for TypeHinting & Future implementations.
+}

--- a/src/Inputs/RefundCreateInput.php
+++ b/src/Inputs/RefundCreateInput.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Sdk\Inputs;
+
+class RefundCreateInput implements InputInterface
+{
+    /**
+     * Rvvup's Order ID to Refund.
+     *
+     * @var string
+     */
+    private $orderId;
+
+    /**
+     * Amount to Refund.
+     *
+     * @var string
+     */
+    private $amount;
+
+    /**
+     * Currency of Refund.
+     *
+     * @var string
+     */
+    private $currency;
+
+    /**
+     * Idempotency key for request.
+     *
+     * @var string
+     */
+    private $idempotencyKey;
+
+    /**
+     * Reason for Refund.
+     *
+     * @var string
+     */
+    private $reason;
+
+    /**
+     * @param string $orderId
+     * @param string $amount
+     * @param string $currency
+     * @param string $idempotencyKey
+     * @param string $reason
+     * @return void
+     */
+    public function __construct(
+        string $orderId,
+        string $amount,
+        string $currency,
+        string $idempotencyKey,
+        string $reason
+    ) {
+        $this->orderId = $orderId;
+        $this->amount = $amount;
+        $this->currency = $currency;
+        $this->idempotencyKey = $idempotencyKey;
+        $this->reason = $reason;
+    }
+
+    /**
+     * Get Rvvup's Order ID to Refund.
+     *
+     * @return string
+     */
+    public function getOrderId(): string
+    {
+        return $this->orderId;
+    }
+
+    /**
+     * Get Amount to Refund.
+     *
+     * @return string
+     */
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+
+    /**
+     * Get Currency of Refund.
+     *
+     * @return string
+     */
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    /**
+     * Get Reason for Refund.
+     *
+     * @return string
+     */
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * Get Idempotency key for request.
+     *
+     * @return string
+     */
+    public function getIdempotencyKey(): string
+    {
+        return $this->idempotencyKey;
+    }
+}

--- a/tests/HelperTrait.php
+++ b/tests/HelperTrait.php
@@ -11,12 +11,13 @@ namespace Rvvup\Sdk\Tests;
 trait HelperTrait
 {
     /**
+     * @param int|null $length
      * @return string
      * @throws \Exception
      */
-    public function getRandomString(): string
+    public function getRandomString(?int $length = null): string
     {
-        return bin2hex(random_bytes(6));
+        return bin2hex(random_bytes($length ?? 6));
     }
 
     /**

--- a/tests/HelperTrait.php
+++ b/tests/HelperTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Sdk\Tests;
+
+/**
+ * Helper trait to be used across testing functions as an easier replacement of Faker.
+ * Faker\Faker has been archived & PHPFaker is available for PHP versions >=7.4 and also has a large footprint.
+ */
+trait HelperTrait
+{
+    /**
+     * @return string
+     * @throws \Exception
+     */
+    public function getRandomString(): string
+    {
+        return bin2hex(random_bytes(6));
+    }
+
+    /**
+     * @return int
+     * @throws \Exception
+     */
+    public function getRandomNumber(): int
+    {
+        return random_int(1, 100);
+    }
+}

--- a/tests/Unit/CurlTest.php
+++ b/tests/Unit/CurlTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rvvup\Sdk\Tests\Unit;
+
+class CurlTest
+{
+
+}

--- a/tests/Unit/CurlTest.php
+++ b/tests/Unit/CurlTest.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Rvvup\Sdk\Tests\Unit;
-
-class CurlTest
-{
-
-}

--- a/tests/Unit/Factories/Inputs/RefundCreateInputFactoryTest.php
+++ b/tests/Unit/Factories/Inputs/RefundCreateInputFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Sdk\Tests\Unit\Factories\Inputs;
+
+use PHPUnit\Framework\TestCase;
+use Rvvup\Sdk\Factories\Inputs\RefundCreateInputFactory;
+
+/**
+ * @test
+ * @group factory
+ * @group test
+ * @group input
+ */
+class RefundCreateInputFactoryTest extends TestCase
+{
+    /**
+     * Assert that if we use the factory to create the RefundCreateInput object
+     * and we provide null for Reason
+     * the returned created RefundCreateInput reason is an empty string.
+     *
+     * @return void
+     */
+    public function assert_created_input_reason_property_is_empty_string_if_provided_reason_argument_is_null(): void
+    {
+        $factory = new RefundCreateInputFactory();
+
+        $this->assertEmpty($factory->create('ORXXXX', '0000', 'GBP', 'KEY', null)->getReason());
+    }
+}

--- a/tests/Unit/Factories/Inputs/RefundCreateInputFactoryTest.php
+++ b/tests/Unit/Factories/Inputs/RefundCreateInputFactoryTest.php
@@ -10,7 +10,7 @@ use Rvvup\Sdk\Factories\Inputs\RefundCreateInputFactory;
 /**
  * @test
  * @group factory
- * @group test
+ * @group refund
  * @group input
  */
 class RefundCreateInputFactoryTest extends TestCase

--- a/tests/Unit/Factories/Inputs/RefundCreateInputFactoryTest.php
+++ b/tests/Unit/Factories/Inputs/RefundCreateInputFactoryTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Rvvup\Sdk\Factories\Inputs\RefundCreateInputFactory;
 
 /**
- * @test
  * @group factory
  * @group refund
  * @group input
@@ -20,6 +19,10 @@ class RefundCreateInputFactoryTest extends TestCase
      * and we provide null for Reason
      * the returned created RefundCreateInput reason is an empty string.
      *
+     * @test
+     * @group factory
+     * @group refund
+     * @group input
      * @return void
      */
     public function assert_created_input_reason_property_is_empty_string_if_provided_reason_argument_is_null(): void

--- a/tests/Unit/GraphQlSdk/RefundCreateTest.php
+++ b/tests/Unit/GraphQlSdk/RefundCreateTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Rvvup\Sdk\Tests\Unit\GraphQlSdk;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use Rvvup\Sdk\Curl;
+use Rvvup\Sdk\Exceptions\NetworkException;
 use Rvvup\Sdk\Factories\Inputs\RefundCreateInputFactory;
 use Rvvup\Sdk\GraphQlSdk;
 use Rvvup\Sdk\Response;
@@ -105,11 +107,12 @@ class RefundCreateTest extends TestCase
      *
      * @return void
      * @throws \JsonException
-     * @throws \Exception
+     * @throws Exception
      */
     public function assert_exception_on_non_2xx_response_code(): void
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
+
         $curlStub = $this->createStub(Curl::class);
 
         $graphQlSdk = new GraphQlSdk(
@@ -123,6 +126,43 @@ class RefundCreateTest extends TestCase
         );
 
         $response = new Response(400, json_encode($this->refundCreateData, JSON_THROW_ON_ERROR), []);
+
+        $curlStub->method('request')->willReturn($response);
+
+        $inputFactory = new RefundCreateInputFactory();
+
+        $this->assertFalse($graphQlSdk->refundCreate($inputFactory->create(
+            'ORXXXX',
+            '10.00',
+            'GBP',
+            'KEY',
+            'RANDOM REASON'
+        )));
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     * @throws \JsonException
+     */
+    public function assert_network_exception_on_5xx_response_code(): void
+    {
+        $this->expectException(NetworkException::class);
+
+        $curlStub = $this->createStub(Curl::class);
+
+        $graphQlSdk = new GraphQlSdk(
+            'https://endpoint.com/url',
+            'MEXXXXXXX',
+            'AUTH_TOKEN',
+            'USER_AGENT',
+            $curlStub,
+            null,
+            false
+        );
+
+        $response = new Response(random_int(500, 599), json_encode($this->refundCreateData, JSON_THROW_ON_ERROR), []);
 
         $curlStub->method('request')->willReturn($response);
 

--- a/tests/Unit/GraphQlSdk/RefundCreateTest.php
+++ b/tests/Unit/GraphQlSdk/RefundCreateTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Rvvup\Sdk\Curl;
 use Rvvup\Sdk\Factories\Inputs\RefundCreateInputFactory;
 use Rvvup\Sdk\GraphQlSdk;
-use Rvvup\Sdk\Inputs\RefundCreateInput;
 use Rvvup\Sdk\Response;
 
 /**
@@ -17,12 +16,25 @@ use Rvvup\Sdk\Response;
  */
 class RefundCreateTest extends TestCase
 {
+    private $refundCreateData = [
+        'data' => [
+            'refundCreate' => [
+                'id' => 'REXXXXXXX',
+                'amount' => [
+                    'amount' => 10.00,
+                    'currency' => 'GBP'
+                ],
+                'status' => 'SUCCESSFUL'
+            ]
+        ]
+    ];
+
     /**
      * @test
      * @group refund
      *
      * @return void
-     * @throws \Exception
+     * @throws \JsonException
      */
     public function assert_successful_refund_call(): void
     {
@@ -38,20 +50,7 @@ class RefundCreateTest extends TestCase
             false
         );
 
-        $data = [
-            'data' => [
-                'refundCreate' => [
-                    'id' => 'REXXXXXXX',
-                    'amount' => [
-                        'amount' => 10.00,
-                        'currency' => 'GBP'
-                    ],
-                    'status' => 'SUCCESSFUL'
-                ]
-            ]
-        ];
-
-        $response = new Response(200, json_encode($data, JSON_THROW_ON_ERROR), []);
+        $response = new Response(200, json_encode($this->refundCreateData, JSON_THROW_ON_ERROR), []);
 
         $curlStub->method('request')->willReturn($response);
 
@@ -59,7 +58,79 @@ class RefundCreateTest extends TestCase
 
         $this->assertIsArray($graphQlSdk->refundCreate($inputFactory->create(
             'ORXXXX',
-            '0000',
+            '10.00',
+            'GBP',
+            'KEY',
+            'RANDOM REASON'
+        )));
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     * @throws \JsonException
+     */
+    public function assert_false_on_empty_response(): void
+    {
+        $curlStub = $this->createStub(Curl::class);
+
+        $graphQlSdk = new GraphQlSdk(
+            'https://endpoint.com/url',
+            'MEXXXXXXX',
+            'AUTH_TOKEN',
+            'USER_AGENT',
+            $curlStub,
+            null,
+            false
+        );
+
+        $response = new Response(200, json_encode($this->refundCreateData['data'], JSON_THROW_ON_ERROR), []);
+
+        $curlStub->method('request')->willReturn($response);
+
+        $inputFactory = new RefundCreateInputFactory();
+
+        $this->assertFalse($graphQlSdk->refundCreate($inputFactory->create(
+            'ORXXXX',
+            '10.00',
+            'GBP',
+            'KEY',
+            'RANDOM REASON'
+        )));
+    }
+
+    /**
+     * @test
+     *
+     * @return void
+     * @throws \JsonException
+     * @throws \Exception
+     */
+    public function assert_exception_on_non_2xx_response_code(): void
+    {
+        $this->expectException(\Exception::class);
+        $curlStub = $this->createStub(Curl::class);
+
+        $graphQlSdk = new GraphQlSdk(
+            'https://endpoint.com/url',
+            'MEXXXXXXX',
+            'AUTH_TOKEN',
+            'USER_AGENT',
+            $curlStub,
+            null,
+            false
+        );
+
+        $response = new Response(400, json_encode($this->refundCreateData, JSON_THROW_ON_ERROR), []);
+
+        $curlStub->method('request')->willReturn($response);
+
+        $inputFactory = new RefundCreateInputFactory();
+
+        $this->assertFalse($graphQlSdk->refundCreate($inputFactory->create(
+            'ORXXXX',
+            '10.00',
             'GBP',
             'KEY',
             'RANDOM REASON'

--- a/tests/Unit/GraphQlSdk/RefundCreateTest.php
+++ b/tests/Unit/GraphQlSdk/RefundCreateTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Sdk\Tests\Unit\GraphQlSdk;
+
+use PHPUnit\Framework\TestCase;
+use Rvvup\Sdk\Curl;
+use Rvvup\Sdk\Factories\Inputs\RefundCreateInputFactory;
+use Rvvup\Sdk\GraphQlSdk;
+use Rvvup\Sdk\Inputs\RefundCreateInput;
+use Rvvup\Sdk\Response;
+
+/**
+ * @test
+ * @group refund
+ */
+class RefundCreateTest extends TestCase
+{
+    /**
+     * @test
+     * @group refund
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function assert_successful_refund_call(): void
+    {
+        $curlStub = $this->createStub(Curl::class);
+
+        $graphQlSdk = new GraphQlSdk(
+            'https://endpoint.com/url',
+            'MEXXXXXXX',
+            'AUTH_TOKEN',
+            'USER_AGENT',
+            $curlStub,
+            null,
+            false
+        );
+
+        $data = [
+            'data' => [
+                'refundCreate' => [
+                    'id' => 'REXXXXXXX',
+                    'amount' => [
+                        'amount' => 10.00,
+                        'currency' => 'GBP'
+                    ],
+                    'status' => 'SUCCESSFUL'
+                ]
+            ]
+        ];
+
+        $response = new Response(200, json_encode($data, JSON_THROW_ON_ERROR), []);
+
+        $curlStub->method('request')->willReturn($response);
+
+        $inputFactory = new RefundCreateInputFactory();
+
+        $this->assertIsArray($graphQlSdk->refundCreate($inputFactory->create(
+            'ORXXXX',
+            '0000',
+            'GBP',
+            'KEY',
+            'RANDOM REASON'
+        )));
+    }
+}

--- a/tests/Unit/Inputs/RefundCreateInputTest.php
+++ b/tests/Unit/Inputs/RefundCreateInputTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rvvup\Sdk\Tests\Unit\Inputs;
+
+use PHPUnit\Framework\TestCase;
+use Rvvup\Sdk\Inputs\RefundCreateInput;
+use Rvvup\Sdk\Tests\HelperTrait;
+
+/**
+ * @test
+ * @group refund
+ * @group input
+ */
+class RefundCreateInputTest extends TestCase
+{
+    use HelperTrait;
+
+    /**
+     * @test
+     * @group refund
+     * @group input
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function assert_order_id_argument_is_set(): void
+    {
+        $orderId = $this->getRandomString();
+        $input = new RefundCreateInput($orderId, '00', 'GBP', 'KEY', 'Reason');
+        $this->assertEquals($orderId, $input->getOrderId());
+    }
+
+    /**
+     * @test
+     * @group refund
+     * @group input
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function assert_amount_argument_is_set(): void
+    {
+        $amount = $this->getRandomNumber();
+        $input = new RefundCreateInput('ORDASSA', (string) $amount, 'GBP', 'KEY', 'Reason');
+        $this->assertEquals((string) $amount, $input->getAmount());
+    }
+}

--- a/tests/Unit/Inputs/RefundCreateInputTest.php
+++ b/tests/Unit/Inputs/RefundCreateInputTest.php
@@ -9,7 +9,6 @@ use Rvvup\Sdk\Inputs\RefundCreateInput;
 use Rvvup\Sdk\Tests\HelperTrait;
 
 /**
- * @test
  * @group refund
  * @group input
  */

--- a/tests/Unit/Inputs/RefundCreateInputTest.php
+++ b/tests/Unit/Inputs/RefundCreateInputTest.php
@@ -46,4 +46,49 @@ class RefundCreateInputTest extends TestCase
         $input = new RefundCreateInput('ORDASSA', (string) $amount, 'GBP', 'KEY', 'Reason');
         $this->assertEquals((string) $amount, $input->getAmount());
     }
+
+    /**
+     * @test
+     * @group refund
+     * @group input
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function assert_currency_argument_is_set(): void
+    {
+        $currency = $this->getRandomString(3);
+        $input = new RefundCreateInput('ORDASSA', '000', $currency, 'KEY', 'Reason');
+        $this->assertEquals($currency, $input->getCurrency());
+    }
+
+    /**
+     * @test
+     * @group refund
+     * @group input
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function assert_idempotency_key_argument_is_set(): void
+    {
+        $idempotencyKey = $this->getRandomString();
+        $input = new RefundCreateInput('ORDASSA', '000', 'GBP', $idempotencyKey, 'Reason');
+        $this->assertEquals($idempotencyKey, $input->getIdempotencyKey());
+    }
+
+    /**
+     * @test
+     * @group refund
+     * @group input
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function assert_reason_argument_is_set(): void
+    {
+        $reason = $this->getRandomString();
+        $input = new RefundCreateInput('ORDASSA', '000', 'GBP', 'KEY', $reason);
+        $this->assertEquals($reason, $input->getReason());
+    }
 }


### PR DESCRIPTION
- Changed minimum required php version to `7.3` to allow the use of `JSON_THROW_ON_ERROR` during `json` methods. 7.3 is the minimum required version for the Magento module as well.
- Added `RefundCreateInput` & relevant factory. Factory should be used always instead of Input classs
- Added new `refundCreate` API method in `GraphQlSdk` for new mutation
- Added new `Rvvup\Sdk\NetworkException` to thrown on response status code between `500` & `599`. Same `idempotency` key should be used for the same transaction and no new transaction should be attempted
- Unit Tests for new API method & classes