### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,18 +73,3 @@ jobs:
 
       - name: Run PHPUnit
         run: ./vendor/bin/phpunit
-
-      - name: Make code coverage badge
-        uses: timkrase/phpunit-coverage-badge@v1.2.1
-        with:
-          coverage_badge_path: output/coverage.svg
-          push_badge: false
-
-      - name: Git push to image-data branch
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          publish_dir: ./output
-          publish_branch: image-data
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
-          tools: composer, phpunit
+          tools: composer
 
       - name: Get composer cache directory
         id: composer-cache
@@ -72,4 +72,4 @@ jobs:
         run: composer install --no-ansi --no-interaction --no-progress --no-scripts
 
       - name: Run PHPUnit
-        run: ./vendor/phpunit/phpunit
+        run: ./vendor/bin/phpunit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
-          tools: composer, phpstan
+          tools: composer, phpunit
 
       - name: Get composer cache directory
         id: composer-cache
@@ -72,4 +72,4 @@ jobs:
         run: composer install --no-ansi --no-interaction --no-progress --no-scripts
 
       - name: Run PHPUnit
-        run: phpunit
+        run: ./vendor/phpunit/phpunit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,35 +11,65 @@ jobs:
   php-stan:
     name: PHP Stan
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [7.3, 7.4]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: "${{ matrix.php }}"
+          tools: composer, phpstan
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-php-${{ matrix.php}}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-php-${{ matrix.php}}-composer-"
 
       - name: Install dependencies
         run: composer install --no-ansi --no-interaction --no-progress --no-scripts
 
       - name: Run PHPStan
-        run: ./vendor/bin/phpstan
+        run: phpstan
 
   php-unit:
     name: PHP Unit
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ 7.3, 7.4 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: "${{ matrix.php }}"
+          tools: composer, phpstan
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: "${{ steps.composer-cache.outputs.dir }}"
+          key: "${{ runner.os }}-php-${{ matrix.php}}-composer-${{ hashFiles('**/composer.json') }}"
+          restore-keys: "${{ runner.os }}-php-${{ matrix.php}}-composer-"
 
       - name: Install dependencies
         run: composer install --no-ansi --no-interaction --no-progress --no-scripts
 
       - name: Run PHPUnit
-        run: ./vendor/bin/phpunit
+        run: phpunit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,3 +73,18 @@ jobs:
 
       - name: Run PHPUnit
         run: ./vendor/bin/phpunit
+
+      - name: Make code coverage badge
+        uses: timkrase/phpunit-coverage-badge@v1.2.1
+        with:
+          coverage_badge_path: output/coverage.svg
+          push_badge: false
+
+      - name: Git push to image-data branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: ./output
+          publish_branch: image-data
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.3, 7.4]
+        php: [ 7.3, 7.4, 8.1, 8.2 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 7.3, 7.4 ]
+        php: [ 7.3, 7.4, 8.1, 8.2 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,18 +9,18 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-    <report>
-      <clover outputFile="clover.xml"/>
-    </report>
-  </coverage>
-  <testsuites>
-    <testsuite name="Unit">
-      <directory suffix="Test.php">./tests/Unit</directory>
-    </testsuite>
-  </testsuites>
-  <logging/>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <clover outputFile="clover.xml"/>
+        </report>
+    </coverage>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <logging/>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
-    <coverage cacheDirectory=".phpunit.cache/code-coverage" processUncoveredFiles="true">
+    <coverage processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./src</directory>
         </include>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
-    <coverage processUncoveredFiles="true">
+    <coverage cacheDirectory=".phpunit.cache/code-coverage" processUncoveredFiles="true">
         <include>
             <directory suffix=".php">./src</directory>
         </include>


### PR DESCRIPTION
Update github actions PR

Nothing really important, but felt like doing a minor contribution after ages 😄 

- Update to use checkout v4 github action
- Use PHP matrix to perform static analysis & tests to PHP version `7.3`, `7.4`, `8.1`, `8.2`
- Add installable tools to php setup github action
- Add cache github action to save & load vendor packages from cache instead of re-installing
- Indentation to `phpunit.xml.dist` file