### PR TITLE
PHP 8.4 compat changes

### DIFF
--- a/src/GraphQlSdk.php
+++ b/src/GraphQlSdk.php
@@ -76,7 +76,7 @@ class GraphQlSdk
      * @param array|null $inputOptions
      * @return array
      */
-    public function getMethods(string $cartTotal = null, string $currency = null, array $inputOptions = null): array
+    public function getMethods(?string $cartTotal = null, ?string $currency = null, ?array $inputOptions = null): array
     {
         $query = <<<'QUERY'
 query merchant ($id: ID!, $total: MoneyInput) {
@@ -773,7 +773,7 @@ QUERY;
      * @throws NetworkException
      * @throws \JsonException
      */
-    public function voidPayment(string $orderId, string $paymentId, string $reason = null)
+    public function voidPayment(string $orderId, string $paymentId, ?string $reason = null)
     {
         $query = <<<'QUERY'
 mutation paymentVoid ($input: PaymentVoidInput!) {
@@ -1053,7 +1053,7 @@ QUERY;
      * @throws \JsonException
      * @throws \Exception
      */
-    private function doRequest($query, $variables = null, array $inputOptions = null)
+    private function doRequest($query, $variables = null, ?array $inputOptions = null)
     {
         $data = ["query" => $query];
         if ($variables !== null) {

--- a/src/Rest/Options/RvvupClientOptions.php
+++ b/src/Rest/Options/RvvupClientOptions.php
@@ -23,7 +23,7 @@ class RvvupClientOptions
      * @param string|null $baseUrl
      * @param string|null $merchantId
      */
-    public function __construct(string $baseUrl = null, string $merchantId = null, string $userAgent = null)
+    public function __construct(?string $baseUrl = null, ?string $merchantId = null, ?string $userAgent = null)
     {
         $this->baseUrl = $baseUrl;
         $this->merchantId = $merchantId;


### PR DESCRIPTION
There were a large number of files here that had incompatible code with PHP 8.4
These were all `implicitly nullable via default value null` errors, and have all been resolved.

As this is a dependency of the `rvvup/module-magento-payments` and `rvvup/module-magento-payments-hyva-checkout` packages, and both those modules have been brought up to PHP 8.4 compatability, this should also be brought up to that same standard